### PR TITLE
feat(parser): add function to display AST statistics and fix `Clippy` warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img src="https://github.com/ash-project/igniter/blob/main/logos/igniter-logo-small.png?raw=true#gh-light-mode-only" alt="Logo Light" width="250">
 <img src="https://github.com/ash-project/igniter/blob/main/logos/igniter-logo-small.png?raw=true#gh-dark-mode-only" alt="Logo Dark" width="250">
 
-[![CI](https://github.com/ash-project/igniter/actions/workflows/elixir.yml/badge.svg)](https://github.com/ash-project/igniter/actions/workflows/elixir.yml)
-[![Hex version badge](https://img.shields.io/hexpm/v/igniter.svg)](https://hex.pm/packages/igniter)
-[![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/igniter)
+[![CI](https://github.com/ash-project/igniter/actions/workflows/elixir.yml/badge.svg)](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml)
+[![Hex version badge](https://img.shields.io/hexpm/v/igniter.svg)](https://hex.pm/packages/igniter_js)
+[![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/igniter_js)
 
 # IgniterJs
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://github.com/ash-project/igniter/blob/main/logos/igniter-logo-small.png?raw=true#gh-light-mode-only" alt="Logo Light" width="250">
 <img src="https://github.com/ash-project/igniter/blob/main/logos/igniter-logo-small.png?raw=true#gh-dark-mode-only" alt="Logo Dark" width="250">
 
-[![CI](https://github.com/ash-project/igniter/actions/workflows/elixir.yml/badge.svg)](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml)
+[![CI](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml/badge.svg)](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml)
 [![Hex version badge](https://img.shields.io/hexpm/v/igniter.svg)](https://hex.pm/packages/igniter_js)
 [![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/igniter_js)
 

--- a/lib/igniter_js/native.ex
+++ b/lib/igniter_js/native.ex
@@ -40,5 +40,7 @@ defmodule IgniterJs.Native do
 
   def remove_objects_of_hooks_from_ast_nif(_file_content, _object_names), do: error()
 
+  def statistics_from_ast_nif(_file_content), do: error()
+
   defp error, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/igniter_js/parsers/javascript/parser.ex
+++ b/lib/igniter_js/parsers/javascript/parser.ex
@@ -184,4 +184,38 @@ defmodule IgniterJs.Parsers.Javascript.Parser do
       type
     )
   end
+
+  @doc """
+  Retrieve statistical information about the JavaScript source code, such as the number of
+  functions, classes, debugger statements, imports, try-catch blocks, and throw statements.
+
+  This function accepts either the content of the JavaScript file or the path to the file,
+  and returns a tuple with the status, function atom, and the extracted data as a map.
+
+  ## Examples
+
+  ```elixir
+  alias IgniterJs.Parsers.Javascript.Parser
+
+  # Analyze a JavaScript source file by providing its content
+  Parser.statistics(js_content)
+
+  # Analyze a JavaScript source file by providing its file path
+  Parser.statistics("/path/to/file.js", :path)
+  ```
+  """
+  def statistics(file_path_or_content, type \\ :content) do
+    {status, fn_atom, {_, data}} =
+      call_nif_fn(
+        file_path_or_content,
+        __ENV__.function,
+        fn file_content ->
+          Native.statistics_from_ast_nif(file_content)
+        end,
+        type
+      )
+
+    converted = if is_map(data), do: Map.drop(data, [:__struct__]), else: data
+    {status, fn_atom, converted}
+  end
 end

--- a/native/igniter_js/Cargo.lock
+++ b/native/igniter_js/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,9 +62,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compact_str"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -108,10 +99,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -121,7 +123,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "igniter_js"
-version = "0.0.1"
+version = "0.1.2"
 dependencies = [
  "oxc",
  "rustler",
@@ -160,6 +162,16 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "memchr"
@@ -215,9 +227,9 @@ checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "oxc"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf8f5dfcc7c7b252121efd0c0009ccc8fe15c7c0ed78bbaa3da7c1b9f38283b"
+checksum = "07041e6a6e828b7e1a8f037afe3a8ea2637ea36478283e2f4d1b5997ccb70a89"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -256,19 +268,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c19205a570ffe6b797638180713bfb7c87e5fb0e3764c82632b6bed63e10a9"
+checksum = "82c6c7387edb41be3d764a115672e7be89922ce6df9756cdedfdd9b152ce788c"
 dependencies = [
  "allocator-api2",
  "bumpalo",
+ "simdutf8",
 ]
 
 [[package]]
 name = "oxc_ast"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f09e7b4d18228b53adff6bdb94ff287ffe557d00f401e06c7c5f66238682062"
+checksum = "6b9fee36a81c3ee36c4f2b3acdb9c455971e9804ea399428e773a094025f92b1"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -284,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82148b5e788cf9ea20492c7be3579a0372a156535c2ac0b8b0aa67651a2474da"
+checksum = "453922e0b0c402ff4f94d277d9c99c8f60757ed5a84458133758f8142b8707cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -295,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d4a6e2eb93abc09bc639274a43ff93b8f652634e4e7ee4e943b08268f1600"
+checksum = "48e38fbfbc25e8f6c86889eaeaabf75722eeb22cc6b90b377bab7ca45674e24c"
 dependencies = [
  "bitflags",
  "itertools",
@@ -310,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f2ace1d346a24b63e9bea7cbdd73d15ae8e28d5f6af0e8780dfb6b25bb92a3"
+checksum = "920a84ae7f0f1641d3f1feec7ea946b628fcec7ebd261de7e5c4027ec8ac9319"
 dependencies = [
  "assert-unchecked",
  "bitflags",
@@ -329,10 +342,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_diagnostics"
-version = "0.42.0"
+name = "oxc_data_structures"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69607b06cc5d4e54eabe5f72e924dab326943d920b8f25870c324325305f984"
+checksum = "72c76d3c3b2f2230ff4b941b68e94f85bc8a8b65aafb7708896ba1bdfaabee26"
+dependencies = [
+ "assert-unchecked",
+ "ropey",
+]
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da579fda6c94527afb13b9cb1fb933ba84ec61c77b74296e71c1b60a21b60447"
 dependencies = [
  "oxc-miette",
  "rustc-hash",
@@ -340,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc78c3cad8742f9db34be10997306a67b719ef809cd151245db5d5493d36a31"
+checksum = "e4de4aac4c0bd05848c4523c145a656aeded13d35fd07557dbafad2c34753837"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -353,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57dfaf4522aed562130ad29789149f8844008dce53f7a754031d631a3c7a9d5b"
+checksum = "5567979b29f2c6af66d912bdf68b18244e4716b1bce77da4cb5b54e036a5d7b9"
 
 [[package]]
 name = "oxc_index"
@@ -365,9 +388,9 @@ checksum = "5eca5d9726cd0a6e433debe003b7bc88b2ecad0bb6109f0cef7c55e692139a34"
 
 [[package]]
 name = "oxc_mangler"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f074ae04248cbb64a8196b7638a0a7062354033d1546dae91267baf4cfb2c7"
+checksum = "a2334e925fbaed19d13204aa98379000cf7eb555f8c9b2b714f10b7e6f7671c6"
 dependencies = [
  "itertools",
  "oxc_ast",
@@ -378,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac7ddf81599e98604c51176934549e5bef3944dbd4138c78e2c57cc679300d"
+checksum = "c9f3b136bd0b203164e03aba7f7ce836df62a7070f847762058439f18296d582"
 dependencies = [
  "assert-unchecked",
  "bitflags",
@@ -401,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5657b1e93c1d568852c07293833acfde0ca7adb298296229280f873e2fb82fe"
+checksum = "ecf141ba4acfed1b65b6393737dc7f15407a4bd0fff16677ca6dedac45a08468"
 dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
@@ -417,16 +440,17 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1b9f2708051b8e6588c6f376e0e61b095263d5b98e94fa1c08bd97213d61ad"
+checksum = "63066ff564e45261d0c86c783b2a9208d6604de2b4bd54004e062358cb66b64f"
 dependencies = [
  "assert-unchecked",
- "indexmap",
+ "hashbrown",
  "itertools",
  "oxc_allocator",
  "oxc_ast",
  "oxc_cfg",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
@@ -434,6 +458,7 @@ dependencies = [
  "oxc_syntax",
  "phf",
  "rustc-hash",
+ "self_cell",
 ]
 
 [[package]]
@@ -452,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f30db7710245b69ea6ac977b4a846144369bc5621a8c8376faa6172dc87eaf"
+checksum = "afcf2e6f8c8f9c0019b7d82412ffe9171bdda72f8b3beba961abdfef4065f0bb"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -465,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfc39f2110677d0dc40452037eb4349820a6d265ca323a6dfb89595db2490e8"
+checksum = "754c63ade3a31289e4605845e1e9ca40c34b40bf10e0e6b91634ec7ad97ade97"
 dependencies = [
  "assert-unchecked",
  "bitflags",
@@ -546,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -569,33 +594,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "regex-lite"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
-name = "regex-automata"
-version = "0.4.9"
+name = "ropey"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
+ "smallvec",
+ "str_indices",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
@@ -605,20 +617,21 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustler"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94bdfa68c0388cbd725f1ca54e975956482c262599e5cced04a903eec918b7f"
+checksum = "5a9f6bb374bf0a1431cff92ee6a89e39b9978fa4dbccc4137605be4ed5118779"
 dependencies = [
  "inventory",
+ "libloading",
+ "regex-lite",
  "rustler_codegen",
- "rustler_sys",
 ]
 
 [[package]]
 name = "rustler_codegen"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996dc019acb78b91b4e0c1bd6fa2cd509a835d309de762dc15213b97eac399da"
+checksum = "f7914359a19fff34b2f0e9d4b7d4b02ca5ee597e52804c7472802b25e1ec543e"
 dependencies = [
  "heck",
  "inventory",
@@ -628,20 +641,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustler_sys"
-version = "2.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd0e2c955cfc86ea4680067e1d5e711427b43f7befcb6e23c7807cf3dd90e97"
-dependencies = [
- "regex",
- "unreachable",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -656,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
+name = "self_cell"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,18 +672,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -683,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -694,10 +703,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -712,10 +733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "syn"
-version = "2.0.90"
+name = "str_indices"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "syn"
+version = "2.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,22 +811,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/native/igniter_js/Cargo.toml
+++ b/native/igniter_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "igniter_js"
-version = "0.0.1"
+version = "0.1.2"
 authors = ["Shahryar Tavakkoli"]
 edition = "2021"
 
@@ -10,5 +10,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-oxc = { version = "0.42.0", features = ["codegen"] }
-rustler = { version = "0.34.0" }
+oxc = { version = "0.44.0", features = ["codegen"] }
+rustler = { version = "0.35.1" }

--- a/native/igniter_js/src/atoms.rs
+++ b/native/igniter_js/src/atoms.rs
@@ -13,5 +13,6 @@ rustler::atoms! {
     find_live_socket_node_from_ast,
     extend_hook_object_to_ast_nif,
     remove_objects_of_hooks_from_ast_nif,
+    statistics_from_ast_nif,
     // Resource Atoms
 }

--- a/native/igniter_js/src/helpers.rs
+++ b/native/igniter_js/src/helpers.rs
@@ -43,12 +43,12 @@ use rustler::{Encoder, Env, NifResult, Term};
 /// This function is useful for building consistent response formats
 /// when integrating Rust code with Elixir applications.
 
-pub fn encode_response<'a, T>(
-    env: Env<'a>,
+pub fn encode_response<T>(
+    env: Env<'_>,
     status: rustler::types::atom::Atom,
     source: rustler::types::atom::Atom,
     message: T,
-) -> NifResult<Term<'a>>
+) -> NifResult<Term<'_>>
 where
     T: Encoder,
 {

--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -71,7 +71,7 @@ pub fn source_to_ast<'a>(
 /// # Returns
 /// A `Result` containing `true` if the module is imported, `false` otherwise,
 /// or an error message if parsing fails.
-pub fn is_module_imported_from_ast<'a>(
+pub fn is_module_imported_from_ast(
     file_content: &str,
     module_name: &str,
     allocator: &Allocator,
@@ -107,7 +107,7 @@ pub fn is_module_imported_from_ast<'a>(
 /// # Behavior
 /// - Ensures duplicate imports are skipped.
 /// - Inserts new import statements after existing ones or at the top if none exist.
-pub fn insert_import_to_ast<'a>(
+pub fn insert_import_to_ast(
     file_content: &str,
     import_lines: &str,
     allocator: &Allocator,
@@ -174,10 +174,10 @@ pub fn insert_import_to_ast<'a>(
 /// # Behavior
 /// - Retains all other import statements and code structure.
 /// - Removes only the specified modules from the import declarations.
-pub fn remove_import_from_ast<'a>(
+pub fn remove_import_from_ast(
     file_content: &str,
     modules: impl IntoIterator<Item = impl AsRef<str>>,
-    allocator: &'a Allocator,
+    allocator: &Allocator,
 ) -> Result<String, String> {
     // Parse the source file into AST
     let mut parsed = source_to_ast(file_content, allocator)?;
@@ -297,7 +297,7 @@ pub fn extend_hook_object_to_ast<'a>(
 
         if let Expression::ObjectExpression(obj_expr) = hooks_property {
             for name in names {
-                let new_property = create_and_import_object_into_hook(name.as_ref(), allocator);
+                let new_property = create_and_import_object_into_hook(name, allocator);
                 obj_expr.properties.push(new_property)
             }
         }

--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -23,11 +23,11 @@ use oxc::{
     allocator::{Allocator, Box as OXCBox, Vec as OXCVec},
     ast::ast::{
         Argument, Expression, IdentifierName, IdentifierReference, NewExpression, ObjectExpression,
-        ObjectProperty, ObjectPropertyKind, Program, PropertyKey, PropertyKind, Statement,
+        ObjectProperty, ObjectPropertyKind, PropertyKey, PropertyKind, Statement,
         VariableDeclarator,
     },
     codegen::Codegen,
-    parser::{ParseOptions, Parser},
+    parser::{ParseOptions, Parser, ParserReturn},
     span::{Atom, SourceType, Span},
 };
 
@@ -47,7 +47,7 @@ use std::cell::Cell;
 pub fn source_to_ast<'a>(
     file_content: &'a str,
     allocator: &'a Allocator,
-) -> Result<Program<'a>, String> {
+) -> Result<ParserReturn<'a>, String> {
     let source_type = SourceType::default();
     let parser = Parser::new(allocator, file_content, source_type).with_options(ParseOptions {
         parse_regular_expression: true,
@@ -55,7 +55,7 @@ pub fn source_to_ast<'a>(
     });
 
     let parse_result = parser.parse();
-    Ok(parse_result.program)
+    Ok(parse_result)
 }
 
 /// Checks if a specific module is imported in the JavaScript source code.
@@ -76,9 +76,9 @@ pub fn is_module_imported_from_ast<'a>(
     module_name: &str,
     allocator: &Allocator,
 ) -> Result<bool, String> {
-    let program = source_to_ast(file_content, allocator)?;
+    let parsed = source_to_ast(file_content, allocator)?;
 
-    for node in program.body {
+    for node in parsed.program.body {
         if let Statement::ImportDeclaration(import_decl) = node {
             if import_decl.source.value == module_name {
                 return Ok(true);
@@ -112,29 +112,22 @@ pub fn insert_import_to_ast<'a>(
     import_lines: &str,
     allocator: &Allocator,
 ) -> Result<String, String> {
-    let mut program = source_to_ast(file_content, allocator)?;
+    let mut parsed = source_to_ast(file_content, allocator)?;
 
     for import_line in import_lines.lines() {
-        let import_source_type = SourceType::default();
-        let parser =
-            Parser::new(allocator, import_line, import_source_type).with_options(ParseOptions {
-                parse_regular_expression: true,
-                ..ParseOptions::default()
-            });
-
-        let parsed_result = parser.parse();
-        if let Some(errors) = parsed_result.errors.first() {
+        let new_parsed = source_to_ast(import_line, allocator)?;
+        if let Some(errors) = new_parsed.errors.first() {
             return Err(format!("Failed to parse import line: {:?}", errors));
         }
 
-        let new_import = parsed_result
+        let new_import = new_parsed
             .program
             .body
             .into_iter()
             .find(|node| matches!(node, Statement::ImportDeclaration(_)))
             .ok_or_else(|| "No import declaration found in parsed import line".to_string())?;
 
-        if program.body.iter().any(|node| {
+        if parsed.program.body.iter().any(|node| {
             matches!(
                 (node, &new_import),
                 (
@@ -146,18 +139,19 @@ pub fn insert_import_to_ast<'a>(
             continue; // Skip duplicate imports
         }
 
-        let position = program
+        let position = parsed
+            .program
             .body
             .iter()
             .rposition(|node| matches!(node, Statement::ImportDeclaration(_)))
             .map(|index| index + 1)
             .unwrap_or(0);
 
-        program.body.insert(position, new_import);
+        parsed.program.body.insert(position, new_import);
     }
 
     let codegen = Codegen::new();
-    let generated_code = codegen.build(&program).code;
+    let generated_code = codegen.build(&parsed.program).code;
 
     Ok(generated_code)
 }
@@ -186,7 +180,7 @@ pub fn remove_import_from_ast<'a>(
     allocator: &'a Allocator,
 ) -> Result<String, String> {
     // Parse the source file into AST
-    let mut program = source_to_ast(file_content, allocator)?;
+    let mut parsed = source_to_ast(file_content, allocator)?;
 
     // Find and remove the specified import declaration
     let modules: Vec<String> = modules
@@ -194,7 +188,7 @@ pub fn remove_import_from_ast<'a>(
         .map(|n| n.as_ref().to_string())
         .collect();
 
-    program.body.retain(|node| {
+    parsed.program.body.retain(|node| {
         if let Statement::ImportDeclaration(import_decl) = node {
             let source_value = import_decl.source.value.to_string();
             !modules.contains(&source_value)
@@ -204,7 +198,7 @@ pub fn remove_import_from_ast<'a>(
     });
 
     let codegen = Codegen::new();
-    let generated_code = codegen.build(&program).code;
+    let generated_code = codegen.build(&parsed.program).code;
     Ok(generated_code)
 }
 
@@ -223,8 +217,8 @@ pub fn remove_import_from_ast<'a>(
 /// # Behavior
 /// - Iterates through all `VariableDeclaration` nodes in the AST to check
 ///   for a variable with the identifier `liveSocket`.
-pub fn find_live_socket_node_from_ast<'a>(program: &'a Program<'a>) -> Result<bool, bool> {
-    if program.body.iter().any(|node| {
+pub fn find_live_socket_node_from_ast<'a>(parsed: &'a ParserReturn<'a>) -> Result<bool, bool> {
+    if parsed.program.body.iter().any(|node| {
         if let Statement::VariableDeclaration(var_decl) = node {
             var_decl.declarations.iter().any(|decl| {
                 decl.id
@@ -284,13 +278,13 @@ pub fn extend_hook_object_to_ast<'a>(
     names: impl IntoIterator<Item = &'a str>,
     allocator: &Allocator,
 ) -> Result<String, String> {
-    let mut program = source_to_ast(file_content, allocator)?;
+    let mut parsed = source_to_ast(file_content, allocator)?;
 
-    if find_live_socket_node_from_ast(&program).is_err() {
+    if find_live_socket_node_from_ast(&parsed).is_err() {
         return Err("liveSocket not found.".to_string());
     }
 
-    let maybe_properties = get_properties(&mut program.body);
+    let maybe_properties = get_properties(&mut parsed.program.body);
     if let Some(properties) = maybe_properties {
         let hooks_property = match find_hooks_property(properties) {
             Some(prop) => prop,
@@ -312,7 +306,7 @@ pub fn extend_hook_object_to_ast<'a>(
     }
 
     let codegen = Codegen::new();
-    let generated_code = codegen.build(&program).code;
+    let generated_code = codegen.build(&parsed.program).code;
     Ok(generated_code)
 }
 
@@ -344,13 +338,13 @@ pub fn remove_objects_of_hooks_from_ast(
     object_names: impl IntoIterator<Item = impl AsRef<str>>,
     allocator: &Allocator,
 ) -> Result<String, String> {
-    let mut program = source_to_ast(file_content, allocator)?;
+    let mut parsed = source_to_ast(file_content, allocator)?;
 
-    if find_live_socket_node_from_ast(&program).is_err() {
+    if find_live_socket_node_from_ast(&parsed).is_err() {
         return Err("liveSocket not found.".to_string());
     }
 
-    let maybe_properties = get_properties(&mut program.body);
+    let maybe_properties = get_properties(&mut parsed.program.body);
     if let Some(properties) = maybe_properties {
         let hooks_property = match find_hooks_property(properties) {
             Some(prop) => prop,
@@ -381,7 +375,7 @@ pub fn remove_objects_of_hooks_from_ast(
     }
 
     let codegen = Codegen::new();
-    let generated_code = codegen.build(&program).code;
+    let generated_code = codegen.build(&parsed.program).code;
     Ok(generated_code)
 }
 
@@ -526,8 +520,8 @@ mod tests {
 
         match source_to_ast(js_content, allocator) {
             Ok(ast) => {
-                println!("{:#?}", ast.body);
-                assert!(!ast.body.is_empty(), "AST body should not be empty");
+                println!("{:#?}", ast.program.body);
+                assert!(!ast.program.body.is_empty(), "AST body should not be empty");
             }
             Err(e) => panic!("Error while parsing AST: {}", e),
         }

--- a/native/igniter_js/src/parsers/javascript/ast_ex.rs
+++ b/native/igniter_js/src/parsers/javascript/ast_ex.rs
@@ -1,6 +1,7 @@
 use crate::atoms;
 use crate::helpers::encode_response;
 use crate::parsers::javascript::ast::*;
+use crate::parsers::javascript::ast_statistics::{source_visitor, ASTStatisticsResultType};
 use oxc::allocator::Allocator;
 use rustler::{Env, NifResult, Term};
 
@@ -133,6 +134,22 @@ fn remove_objects_of_hooks_from_ast_nif(
             Ok(updated_code) => (atoms::ok(), updated_code),
             Err(error_msg) => (atoms::error(), error_msg),
         };
+
+    encode_response(env, status, fn_atom, result)
+}
+
+#[rustler::nif]
+fn statistics_from_ast_nif(env: Env, file_content: String) -> NifResult<Term> {
+    let allocator = Allocator::default(); // Create an OXC allocator
+    let fn_atom = atoms::statistics_from_ast_nif();
+
+    let (status, result) = match source_visitor(&file_content, &allocator) {
+        Ok(updated_code) => (
+            atoms::ok(),
+            ASTStatisticsResultType::Statistics(updated_code),
+        ),
+        Err(error_msg) => (atoms::error(), ASTStatisticsResultType::Error(error_msg)),
+    };
 
     encode_response(env, status, fn_atom, result)
 }

--- a/native/igniter_js/src/parsers/javascript/ast_statistics.rs
+++ b/native/igniter_js/src/parsers/javascript/ast_statistics.rs
@@ -1,3 +1,10 @@
+//! # ASTStatistics Module
+//!
+//! This module provides functionality to parse JavaScript source code and
+//! extract statistics about specific AST nodes,
+//! such as functions, classes, debugger statements, imports, try-catch blocks, and throw statements.
+//! It is designed to work with Elixir via the `rustler` library.
+
 #![allow(clippy::print_stdout)]
 use crate::parsers::javascript::ast::source_to_ast;
 use oxc::{
@@ -12,11 +19,19 @@ use oxc::{
     syntax::scope::ScopeFlags,
 };
 
-use rustler::NifStruct;
+use rustler::{NifStruct, NifTaggedEnum};
 
+#[derive(NifTaggedEnum)]
+pub enum ASTStatisticsResultType {
+    Statistics(ASTStatistics),
+    Error(String),
+}
+
+/// Represents the statistics gathered from JavaScript source code.
+/// Each field corresponds to a specific type of AST node.
 #[derive(Debug, Default, NifStruct)]
-#[module = "Elixir.IgniterJs.Native.Parsers.Javascript.Visitor.ASTNodesInfo"]
-pub struct ASTNodesInfo {
+#[module = "IgniterJs.Native.Parsers.Javascript.ASTStatistics"]
+pub struct ASTStatistics {
     functions: usize,
     classes: usize,
     debuggers: usize,
@@ -25,23 +40,35 @@ pub struct ASTNodesInfo {
     throws: usize,
 }
 
-pub fn source_visitor<'a>(
-    file_content: &str,
-    allocator: &Allocator,
-) -> Result<ASTNodesInfo, String> {
+/// Parses the given JavaScript source code and collects statistics about the AST nodes.
+///
+/// # Arguments
+/// - `file_content`: A string slice containing the JavaScript source code.
+/// - `allocator`: A reference to the allocator used for AST node allocation.
+///
+/// # Returns
+/// A result containing `ASTStatistics` with statistics about the parsed source code or an error message if parsing fails.
+///
+/// # Example
+/// ```rust
+/// let allocator = Allocator::default();
+/// let file_content = "function foo() { console.log('Hello'); }";
+/// let result = source_visitor(file_content, &allocator);
+/// assert!(result.is_ok());
+/// ```
+pub fn source_visitor(file_content: &str, allocator: &Allocator) -> Result<ASTStatistics, String> {
     let parsed = source_to_ast(file_content, allocator)?;
 
     if let Some(errors) = parsed.errors.first() {
         return Err(format!("Failed to parse source: {:?}", errors));
     }
 
-    let mut ast_pass = ASTNodesInfo::default();
+    let mut ast_pass = ASTStatistics::default();
     ast_pass.visit_program(&parsed.program);
-    println!("{ast_pass:?}");
     Ok(ast_pass)
 }
 
-impl<'a> Visit<'a> for ASTNodesInfo {
+impl<'a> Visit<'a> for ASTStatistics {
     fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         self.functions += 1;
         walk::walk_function(self, func, flags);
@@ -101,6 +128,13 @@ mod tests {
                 debugger;
             }
         "#;
-        assert!(source_visitor(file_content, &allocator).is_ok());
+        let parsed = source_visitor(file_content, &allocator).unwrap();
+        println!("{:#?}", parsed);
+        assert_eq!(parsed.functions, 2);
+        assert_eq!(parsed.classes, 1);
+        assert_eq!(parsed.debuggers, 2);
+        assert_eq!(parsed.imports, 2);
+        assert_eq!(parsed.trys, 0);
+        assert_eq!(parsed.throws, 0);
     }
 }

--- a/native/igniter_js/src/parsers/javascript/mod.rs
+++ b/native/igniter_js/src/parsers/javascript/mod.rs
@@ -1,2 +1,3 @@
 pub mod ast;
 pub mod ast_ex;
+pub mod visitor;

--- a/native/igniter_js/src/parsers/javascript/mod.rs
+++ b/native/igniter_js/src/parsers/javascript/mod.rs
@@ -1,3 +1,3 @@
 pub mod ast;
 pub mod ast_ex;
-pub mod visitor;
+pub mod ast_statistics;

--- a/native/igniter_js/src/parsers/javascript/visitor.rs
+++ b/native/igniter_js/src/parsers/javascript/visitor.rs
@@ -1,0 +1,78 @@
+#![allow(clippy::print_stdout)]
+use crate::parsers::javascript::ast::source_to_ast;
+use oxc::{
+    allocator::Allocator,
+    ast::{
+        ast::{Class, Function, TSImportType},
+        visit::walk,
+        Visit,
+    },
+    syntax::scope::ScopeFlags,
+};
+
+use rustler::NifStruct;
+
+#[derive(Debug, Default, NifStruct)]
+#[module = "Elixir.IgniterJs.Native.Parsers.Javascript.Visitor.CountASTNodes"]
+pub struct CountASTNodes {
+    functions: usize,
+    classes: usize,
+    ts_import_types: usize,
+}
+
+pub fn source_visitor<'a>(
+    file_content: &str,
+    allocator: &Allocator,
+) -> Result<CountASTNodes, Box<dyn std::error::Error>> {
+    let parsed = source_to_ast(file_content, allocator)?;
+
+    let mut ast_pass = CountASTNodes::default();
+    ast_pass.visit_program(&parsed.program);
+    println!("{ast_pass:?}");
+    Ok(ast_pass)
+}
+
+impl<'a> Visit<'a> for CountASTNodes {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        self.functions += 1;
+        walk::walk_function(self, func, flags);
+    }
+
+    fn visit_class(&mut self, class: &Class<'a>) {
+        self.classes += 1;
+        walk::walk_class(self, class);
+    }
+
+    fn visit_ts_import_type(&mut self, ty: &TSImportType<'a>) {
+        self.ts_import_types += 1;
+        walk::walk_ts_import_type(self, ty);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc::allocator::Allocator;
+
+    fn create_allocator<'a>() -> &'a Allocator {
+        let allocator = Box::new(Allocator::default());
+        Box::leak(allocator)
+    }
+
+    #[test]
+    fn test_source_visitor() {
+        let allocator = create_allocator();
+        let file_content = r#"
+            import { foo } from 'bar';
+            class Foo {
+                constructor() {
+                    console.log('Hello');
+                }
+            }
+            function bar() {
+                console.log('World');
+            }
+        "#;
+        assert!(source_visitor(file_content, &allocator).is_ok());
+    }
+}

--- a/test/assets/errorImport.js
+++ b/test/assets/errorImport.js
@@ -1,0 +1,2 @@
+import { foo } from "module-name";
+import * from "error-module-name";

--- a/test/assets/validASTStatistics.js
+++ b/test/assets/validASTStatistics.js
@@ -1,0 +1,13 @@
+import { foo } from "bar";
+import * as jar from "jar";
+console.log("Start JS file");
+class Foo {
+  constructor() {
+    debugger;
+    console.log("Hello");
+  }
+}
+function bar() {
+  console.log("World");
+  debugger;
+}

--- a/test/parsers/javascript/parser_test.exs
+++ b/test/parsers/javascript/parser_test.exs
@@ -8,6 +8,8 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
   @invalid_app_without_live_socket_object "test/assets/invalidAppWithoutLiveSockerObject.js"
   @invalid_app_without_hooks_key "test/assets/invalidAppWithoutHooksKey.js"
   @valid_app_with_hooks_objects "test/assets/validAppWithSomeHooksObjects.js"
+  @invalid_error_import "test/assets/errorImport.js"
+  @valid_ast_statistics "test/assets/validASTStatistics.js"
 
   test "User requested module imported? :: module_imported" do
     {:ok, :module_imported, true} =
@@ -260,5 +262,16 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
              )
 
     ^considerd_output = assert output
+  end
+
+  test "Get statistics from the given file or content :: statistics" do
+    {:error, :statistics, _statistics} = assert Parser.statistics(@invalid_error_import, :path)
+    {:ok, :statistics, statistics} = assert Parser.statistics(@valid_ast_statistics, :path)
+     2 = assert statistics.functions
+     1 = assert statistics.classes
+     2 = assert statistics.debuggers
+     2 = assert statistics.imports
+     0 = assert statistics.trys
+     0 = assert statistics.throws
   end
 end

--- a/test/parsers/javascript/parser_test.exs
+++ b/test/parsers/javascript/parser_test.exs
@@ -267,11 +267,11 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
   test "Get statistics from the given file or content :: statistics" do
     {:error, :statistics, _statistics} = assert Parser.statistics(@invalid_error_import, :path)
     {:ok, :statistics, statistics} = assert Parser.statistics(@valid_ast_statistics, :path)
-     2 = assert statistics.functions
-     1 = assert statistics.classes
-     2 = assert statistics.debuggers
-     2 = assert statistics.imports
-     0 = assert statistics.trys
-     0 = assert statistics.throws
+    2 = assert statistics.functions
+    1 = assert statistics.classes
+    2 = assert statistics.debuggers
+    2 = assert statistics.imports
+    0 = assert statistics.trys
+    0 = assert statistics.throws
   end
 end


### PR DESCRIPTION
In this PR, I have aimed to update the Rust dependencies and resolve all warnings previously raised by `Clippy` in the earlier version.

In this version, we provide limited support for the following:
```rust
assert_eq!(parsed.functions, 2);
assert_eq!(parsed.classes, 1);
assert_eq!(parsed.debuggers, 2);
assert_eq!(parsed.imports, 2);
assert_eq!(parsed.trys, 0);
assert_eq!(parsed.throws, 0);
```

#### Note:
I have not changed the version to allow any necessary build adjustments to be made. If this needs to be addressed, please let me know so I can update it, or feel free to handle it yourself.

After merging this, a few functions for working with the AST will need to be implemented. I will proceed to work on examples for them.

> Please squash this pull request as it contains too many commits. 

Thank you,
Shahryar