### PR TITLE
feat: add function to extend limited objects and prevent duplicate object names during extending hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://github.com/ash-project/igniter/blob/main/logos/igniter-logo-small.png?raw=true#gh-dark-mode-only" alt="Logo Dark" width="250">
 
 [![CI](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml/badge.svg)](https://github.com/ash-project/igniter_js/actions/workflows/elixir.yml)
-[![Hex version badge](https://img.shields.io/hexpm/v/igniter.svg)](https://hex.pm/packages/igniter_js)
+[![Hex version badge](https://img.shields.io/hexpm/v/igniter_js.svg)](https://hex.pm/packages/igniter_js)
 [![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/igniter_js)
 
 # IgniterJs

--- a/lib/igniter_js/native.ex
+++ b/lib/igniter_js/native.ex
@@ -42,5 +42,8 @@ defmodule IgniterJs.Native do
 
   def statistics_from_ast_nif(_file_content), do: error()
 
+  def extend_var_object_property_by_names_to_ast_nif(_file_content, _var_name, _object_names),
+    do: error()
+
   defp error, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/igniter_js/parsers/javascript/parser.ex
+++ b/lib/igniter_js/parsers/javascript/parser.ex
@@ -218,4 +218,22 @@ defmodule IgniterJs.Parsers.Javascript.Parser do
     converted = if is_map(data), do: Map.drop(data, [:__struct__]), else: data
     {status, fn_atom, converted}
   end
+
+  def extend_var_object_by_object_names(file_path_or_content, var, object_names, type \\ :content)
+
+  def extend_var_object_by_object_names(file_path_or_content, var, object_name, type)
+      when is_binary(object_name) do
+    extend_var_object_by_object_names(file_path_or_content, var, [object_name], type)
+  end
+
+  def extend_var_object_by_object_names(file_path_or_content, var, object_names, type) do
+    call_nif_fn(
+      file_path_or_content,
+      __ENV__.function,
+      fn file_content ->
+        Native.extend_var_object_property_by_names_to_ast_nif(file_content, var, object_names)
+      end,
+      type
+    )
+  end
 end

--- a/lib/igniter_js/parsers/javascript/parser.ex
+++ b/lib/igniter_js/parsers/javascript/parser.ex
@@ -219,6 +219,35 @@ defmodule IgniterJs.Parsers.Javascript.Parser do
     {status, fn_atom, converted}
   end
 
+  @doc """
+    Extend a variable of object type in the given file or content by adding additional objects to it,
+    based on their names.
+
+    This function ensures that duplicate entries are not added during the process.
+
+    This function accepts:
+    - The content or path of the JavaScript file.
+    - The name of the variable to be extended.
+    - A single object name or a list of object names to be added.
+    - The type indicating whether it's content (`:content`) or a path (`:path`).
+
+    It returns a tuple with the status, function atom, and the updated content or an error message
+    if the variable could not be found or modified.
+
+    ## Examples
+
+    ```elixir
+    alias IgniterJs.Parsers.Javascript.Parser
+
+    objects_names = ["OXCTestHook", "MishkaHooks", "MishkaHooks", "OXCTestHook"]
+
+    Parser.extend_var_object_by_object_names(js_content, "Components", "TestHook")
+    Parser.extend_var_object_by_object_names("/path/to/file.js", "Components", objects_names, :path)
+
+    {:error, :extend_var_object_by_object_names, _output} =
+      Parser.extend_var_object_by_object_names("None", "Components", objects_names)
+    ```
+  """
   def extend_var_object_by_object_names(file_path_or_content, var, object_names, type \\ :content)
 
   def extend_var_object_by_object_names(file_path_or_content, var, object_name, type)

--- a/native/igniter_js/Cargo.lock
+++ b/native/igniter_js/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "igniter_js"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "oxc",
  "rustler",

--- a/native/igniter_js/Cargo.toml
+++ b/native/igniter_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "igniter_js"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Shahryar Tavakkoli"]
 edition = "2021"
 

--- a/native/igniter_js/src/atoms.rs
+++ b/native/igniter_js/src/atoms.rs
@@ -14,5 +14,6 @@ rustler::atoms! {
     extend_hook_object_to_ast_nif,
     remove_objects_of_hooks_from_ast_nif,
     statistics_from_ast_nif,
+    extend_var_object_property_by_names_to_ast_nif,
     // Resource Atoms
 }

--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -478,7 +478,7 @@ pub fn extend_var_object_property_by_names_to_ast<'a>(
     match result {
         Some(Ok(_)) => Ok(codegen(&parsed, false)),
         Some(Err(e)) => Err(e),
-        None => Err("Variable not found in javascript body".to_string()),
+        _ => Err("Variable not found in javascript body or js file is invalid".to_string()),
     }
 }
 

--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -430,7 +430,7 @@ pub fn remove_objects_of_hooks_from_ast(
 ///   );
 ///   assert!(result.is_err());
 ///   ```
-
+// Ref: https://users.rust-lang.org/t/123707
 pub fn extend_var_object_property_by_names_to_ast<'a>(
     file_content: &str,
     var_name: &str,
@@ -478,7 +478,7 @@ pub fn extend_var_object_property_by_names_to_ast<'a>(
     match result {
         Some(Ok(_)) => Ok(codegen(&parsed, false)),
         Some(Err(e)) => Err(e),
-        _ => Err("Variable not found in javascript body or js file is invalid".to_string()),
+        _ => Err("Variable not found in javascript body or javascript file is invalid".to_string()),
     }
 }
 

--- a/native/igniter_js/src/parsers/javascript/ast_ex.rs
+++ b/native/igniter_js/src/parsers/javascript/ast_ex.rs
@@ -153,3 +153,30 @@ fn statistics_from_ast_nif(env: Env, file_content: String) -> NifResult<Term> {
 
     encode_response(env, status, fn_atom, result)
 }
+
+#[rustler::nif]
+pub fn extend_var_object_property_by_names_to_ast_nif(
+    env: Env,
+    file_content: String,
+    var_name: String,
+    object_names: Vec<String>,
+) -> NifResult<Term> {
+    let allocator = Allocator::default(); // Create an OXC allocator
+    let names_iter = object_names.iter().map(|s| s.as_str());
+    let (status, result) = match extend_var_object_property_by_names_to_ast(
+        &file_content,
+        &var_name,
+        names_iter,
+        &allocator,
+    ) {
+        Ok(updated_code) => (atoms::ok(), updated_code),
+        Err(error_msg) => (atoms::error(), error_msg),
+    };
+
+    encode_response(
+        env,
+        status,
+        atoms::extend_var_object_property_by_names_to_ast_nif(),
+        result,
+    )
+}

--- a/test/assets/extendVarObject.js
+++ b/test/assets/extendVarObject.js
@@ -1,0 +1,3 @@
+const Components = {};
+
+export default Components;

--- a/test/parsers/javascript/parser_test.exs
+++ b/test/parsers/javascript/parser_test.exs
@@ -10,6 +10,7 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
   @valid_app_with_hooks_objects "test/assets/validAppWithSomeHooksObjects.js"
   @invalid_error_import "test/assets/errorImport.js"
   @valid_ast_statistics "test/assets/validASTStatistics.js"
+  @valid_extend_var_object "test/assets/extendVarObject.js"
 
   test "User requested module imported? :: module_imported" do
     {:ok, :module_imported, true} =
@@ -273,5 +274,34 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
     2 = assert statistics.imports
     0 = assert statistics.trys
     0 = assert statistics.throws
+  end
+
+  test "Extend some objects inside a var object :: extend_var_object_by_object_names" do
+    objects_names = ["OXCTestHook", "MishkaHooks", "MishkaHooks", "OXCTestHook"]
+
+    considerd_output =
+      "const Components = {\n\tOXCTestHook,\n\tMishkaHooks\n};\nexport default Components;\n"
+
+    # It prevents duplicate objects
+    {:ok, :extend_var_object_by_object_names, output} =
+      assert Parser.extend_var_object_by_object_names(
+               @valid_extend_var_object,
+               "Components",
+               objects_names,
+               :path
+             )
+
+    ^considerd_output = assert output
+
+    {:error, :extend_var_object_by_object_names, _output} =
+      assert Parser.extend_var_object_by_object_names("None", "Components", objects_names)
+
+    {:ok, :extend_var_object_by_object_names, _output} =
+      assert Parser.extend_var_object_by_object_names(
+               @valid_extend_var_object,
+               "Components",
+               "TestHook",
+               :path
+             )
   end
 end


### PR DESCRIPTION
In this PR, I have tried to address some essential requirements that were missing. Additionally, I aimed to guide the user-facing functions towards a continuous model, ensuring that duplicate imports or extensions are automatically ignored and the code is generated seamlessly.

#### Example based on https://github.com/mishka-group/mishka_chelekom/issues/181

```js
// assets/vendor/components.js

import CopyMixInstallationHook from "./mixCopy.js";
import CopyColorInstallationHook from "./colorCopy.js";

const Components = {
  CopyMixInstallationHook,
  CopyColorInstallationHook,
};

export default Components;
```

---

Note:
I have not changed the version to allow any necessary build adjustments to be made. If this needs to be addressed, please let me know so I can update it, or feel free to handle it yourself.

> Please squash this pull request as it contains too many commits.