### PR TITLE
feat: improve import deduplication by supporting ImportDefaultSpecifier and ImportNamespaceSpecifier

### DIFF
--- a/native/igniter_js/src/helpers.rs
+++ b/native/igniter_js/src/helpers.rs
@@ -42,7 +42,6 @@ use rustler::{Encoder, Env, NifResult, Term};
 ///
 /// This function is useful for building consistent response formats
 /// when integrating Rust code with Elixir applications.
-
 pub fn encode_response<T>(
     env: Env<'_>,
     status: rustler::types::atom::Atom,

--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -61,7 +61,7 @@ struct ASTVisitImport<'a> {
     operation: Operation,
 }
 
-impl<'a> Default for ASTVisitImport<'a> {
+impl Default for ASTVisitImport<'_> {
     fn default() -> Self {
         Self {
             code: "",
@@ -498,6 +498,7 @@ mod tests {
             import "phoenix_html";
             import { Socket, SocketV1 } from "phoenix";
             import { TS } from "tsobject";
+            import ScrollArea from "./scrollArea.js";
 
             // This is first test we need to have
             console.log("We are here");
@@ -510,6 +511,7 @@ mod tests {
                 import { Socket, SocketV1 } from "phoenix";
                 import { TS } from "tsobject";
                 import { NoneRepeated } from "orepeat";
+                import ScrollArea from "./scrollArea.js";
             "#;
         let result = insert_import_to_ast(code, import).expect("Failed to generate code");
 

--- a/native/igniter_js/src/parsers/javascript/helpers.rs
+++ b/native/igniter_js/src/parsers/javascript/helpers.rs
@@ -121,6 +121,12 @@ fn specifier_equals(new_spec: &ImportSpecifier, existing_spec: &ImportSpecifier)
         (ImportSpecifier::Named(new_named), ImportSpecifier::Named(existing_named)) => {
             new_named.local.sym == existing_named.local.sym
         }
+        (ImportSpecifier::Default(new_named), ImportSpecifier::Default(existing_named)) => {
+            new_named.local.sym == existing_named.local.sym
+        }
+        (ImportSpecifier::Namespace(new_named), ImportSpecifier::Namespace(existing_named)) => {
+            new_named.local.sym == existing_named.local.sym
+        }
         _ => false,
     }
 }

--- a/native/igniter_js/src/parsers/javascript/phoenix.rs
+++ b/native/igniter_js/src/parsers/javascript/phoenix.rs
@@ -31,7 +31,7 @@ impl<'a> HookExtender<'a> {
     }
 }
 
-impl<'a> VisitMut for HookExtender<'a> {
+impl VisitMut for HookExtender<'_> {
     fn visit_mut_var_decl(&mut self, var_decl: &mut VarDecl) {
         if matches!(self.operation, Operation::Edit) {
             for decl in &mut var_decl.decls {
@@ -65,7 +65,7 @@ impl<'a> VisitMut for HookExtender<'a> {
     }
 }
 
-impl<'a> HookExtender<'a> {
+impl HookExtender<'_> {
     fn extend_or_create_hooks(&mut self, obj_expr: &mut ObjectLit) {
         if let Some(hooks_property) = obj_expr.props.iter_mut().find_map(|prop| {
             if let PropOrSpread::Prop(prop) = prop {
@@ -135,7 +135,7 @@ impl<'a> HookExtender<'a> {
     }
 }
 
-impl<'a> HookExtender<'a> {
+impl HookExtender<'_> {
     fn remove_objects_from_hooks(
         &mut self,
         obj_expr: &mut ObjectLit,


### PR DESCRIPTION
In this small pull request, I fixed some warnings and added support for two new import types to prevent duplication.

```
Default | import ScrollArea from "./scrollArea.js";
Named | import { ScrollArea } from "./scrollArea.js";
Namespace | import * as Scroll from "./scrollArea.js";
```

Please do not release it yet, as I need to send a few more updates in other pull requests.
Thank you 🙏🏻♥️