### PR TITLE
refactor(hook_extender): unify impls, avoid spread duplication, and add test

### DIFF
--- a/native/igniter_js/src/parsers/javascript/ast.rs
+++ b/native/igniter_js/src/parsers/javascript/ast.rs
@@ -634,6 +634,34 @@ mod tests {
         let result =
             extend_var_object_property_by_names_to_ast(code, "Components", vec_of_strs.clone());
         assert!(result.is_err());
+
+        let code = r#"
+            import ScrollArea from "./scrollArea.js";
+
+            const Components = {
+              ScrollArea,
+            };
+
+            export default Components;
+            "#;
+
+        let object_names = ["ScrollArea", "NoneComponent"];
+
+        let result = extend_var_object_property_by_names_to_ast(code, "Components", object_names);
+        assert!(result.is_ok());
+
+        let code = r#"
+            import ScrollArea from "./scrollArea.js";
+
+            const Components = {};
+
+            export default Components;
+            "#;
+
+        let object_names = ["ScrollArea", "NoneComponent", "...NoneComponent"];
+        let result = extend_var_object_property_by_names_to_ast(code, "Components", object_names);
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/test/parsers/javascript/parser_test.exs
+++ b/test/parsers/javascript/parser_test.exs
@@ -241,6 +241,36 @@ defmodule IgniterJSTest.Parsers.Javascript.ParserTest do
       "let Hooks = {};\nlet liveSocket = new LiveSocket(\"/live\", Socket, {\n    longPollFallbackMs: 2500,\n    params: {\n        _csrf_token: csrfToken\n    },\n    hooks: {\n        another,\n        something\n    }\n});\n"
 
     ^considerd_output = assert output
+
+    js_input_code =
+      """
+      let Hooks = {};
+      let liveSocket = new LiveSocket("/live", Socket, {
+        longPollFallbackMs: 2500,
+        params: {
+          _csrf_token: csrfToken,
+        },
+        hooks: {
+          something,
+          ...MishkaComponent
+        },
+      });
+      """
+
+    {:ok, :extend_hook_object, output} =
+      assert Parser.extend_hook_object(js_input_code, ["...MishkaComponent", "something"])
+
+    string_counter = fn string, pattern ->
+      Regex.scan(Regex.compile!(pattern), string)
+      |> length()
+    end
+
+    considerd_output =
+      "let Hooks = {};\nlet liveSocket = new LiveSocket(\"/live\", Socket, {\n    longPollFallbackMs: 2500,\n    params: {\n        _csrf_token: csrfToken\n    },\n    hooks: {\n        something,\n        ...MishkaComponent\n    }\n});\n"
+
+    ^considerd_output = assert output
+
+    1 = assert string_counter.(considerd_output, "\\.\\.\\.MishkaComponent")
   end
 
   test "Remove objects of hooks key inside LiveSocket:: remove_objects_from_hooks" do


### PR DESCRIPTION
This Pull Request introduces several optimizations to `HookExtender`. First, all scattered `impl` blocks have been merged into a single `impl` to improve code readability and maintainability. Additionally, a mechanism has been implemented to prevent redundant Spread object duplication, reducing unnecessary allocations. Finally, a unit test has been added to ensure the correctness of these changes. 🚀

Please do not release it yet, as I need to send a few more updates in other pull requests.
Thank you 🙏🏻♥️